### PR TITLE
BUGFIX: Keep ratio on resize

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,9 +1,9 @@
 {
-  "title": "Iframe embeddor",
+  "title": "Iframe embedder",
   "description": "Embed internal or external html files",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 1,
+  "patchVersion": 2,
   "runnable": 1,
   "author": "Amendor AS",
   "license": "cc-by-sa",

--- a/semantics.json
+++ b/semantics.json
@@ -3,19 +3,19 @@
     "label": "Width",
     "name": "width",
     "type": "text",
-    "description": "Width of iFrame in CSS compliant format. Default: \"100%\""
+    "description": "Width of iFrame in CSS compliant format. Default: \"500px\""
+  },
+  {
+    "label": "Minimum width",
+    "name": "minWidth",
+    "type": "text",
+    "description": "Minimum width of iFrame in CSS compliant format. Default: \"300px\""
   },
   {
     "label": "Height",
     "name": "height",
     "type": "text",
     "description": "Height of iFrame in CSS compliant format. Default: \"500px\""
-  },
-  {
-    "label": "Minimum height",
-    "name": "minHeight",
-    "type": "text",
-    "description": "Minimum height of iFrame in CSS compliant format. Default: \"420px\""
   },
   {
     "label": "Source",


### PR DESCRIPTION
Altered the library so that you can enter a "set" width and height into 'content.json', which will enable the library to calculate the desired ratio between width/height for presentation on a website. Also added a field for minimum width, so that the content author can ensure his/her content will be displayed only at optimal sizes.

The library has been tested, and found working, on all major browsers. Tested OS: Windows 7, OSX 10.9, iOS 7.

Consult the commit diff/message for more information.
