### PR TITLE
Fixed issue where urls were showing encoded html entities

### DIFF
--- a/iframe-embed.js
+++ b/iframe-embed.js
@@ -54,14 +54,10 @@ H5P.IFrameEmbed = function (options, contentId) {
   };
 
   this.resize = function () {
-    if(this.parent && this.parent.slides && this.parent.slides.length >= 10) { // checks if the parent has slides and is therefore a course presentation
-      $iframe.css({width: '100%', height: '100%'}); // always set 100% if course pres
-    } else { // default standalone config
-      if(options.resizeSupported) { 
-        $iframe.css(
-          (H5P.isFullscreen) ? {width: '100%', height: '100%'} : getElementSize($iframe)
-        );
-      }
+    if(options.resizeSupported) { 
+      $iframe.css(
+        (H5P.isFullscreen) ? {width: '100%', height: '100%'} : getElementSize($iframe)
+      );
     }
   };
 


### PR DESCRIPTION
If for example you entered a url to be used in an iFrame:

    http://example.com/wp-admin/admin-ajax.php?action=h5p_embed&id=148

it would convert the ampersand character to &amp; in the src attribute of the iframe

    http://example.com/wp-admin/admin-ajax.php?action=h5p_embed&amp;id=148

I used a basic html entity conversion function to rectify this issue. 

I may have also accidentally removed some comments on lines 57 & 58

Hopefully this is of use, 
Cheers,
Tomm