### PR TITLE
Fix encoding of source URL

### DIFF
--- a/iframe-embed.js
+++ b/iframe-embed.js
@@ -32,6 +32,12 @@ H5P.IFrameEmbed = function (options, contentId) {
       }
     }
 
+    // Remove HTML encoding from source
+    iFrameSource = new DOMParser().parseFromString(iFrameSource, 'text/html').documentElement.textContent;
+
+    // Take care of special characters
+    iFrameSource = encodeURI(iFrameSource);
+
     $iframe = $('<iframe/>', {
       src: iFrameSource,
       scrolling: 'no',


### PR DESCRIPTION
Currently, the source URL for the iframe will be HTML-encoded, so there are pages that cannot be embedded, e.g. those that can be configured via GET variables.

When merged in, this issue will be fixed by HTML-decoding the source URL and running it through `encodeURI` to take care of special characters.